### PR TITLE
Fixing small bug on brand new installs in .rvmrc file

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,1 @@
-rvm use 1.9.2@anatomy_of_backbone
+rvm use --create 1.9.2@anatomy_of_backbone


### PR DESCRIPTION
When installing I was getting the following error:

```
Gemset 'anatomy_of_backbone' does not exist, 'rvm gemset create anatomy_of_backbone' first, or append '--create'.
```

This will fix it.
